### PR TITLE
handle wp.components.Icon size attribute

### DIFF
--- a/plugin/admin/src/js/components/icon/index.js
+++ b/plugin/admin/src/js/components/icon/index.js
@@ -42,7 +42,14 @@ const LHIcon = (props) => {
 			`lh-icon icon-${icon?.slug || slug || 'svg'}`
 		);
 
-		return <WPIcon {...props} icon={parsedSvg} className={className} />;
+		return (
+			<WPIcon
+				{...props}
+				icon={parsedSvg}
+				className={className}
+				size={parseInt(icon?.width || icon?.height) || null}
+			/>
+		);
 	}
 
 	return <></>;


### PR DESCRIPTION
See the docs: https://developer.wordpress.org/block-editor/reference-guides/components/icon/#size

Size will default to `24` which sets `width` and `height` attributes to the SVG markup at the backend, resulting in a "square image". That's not what we want for e.g. divider graphics.

We handle `--icon-size` via a wrapper with class `icon`.