### PR TITLE
make <mark> bg color transparent by default

### DIFF
--- a/theme/src/css/src-base/_typography.css
+++ b/theme/src/css/src-base/_typography.css
@@ -115,7 +115,7 @@ acronym {
 
 mark,
 ins {
-	background: #fff9c0;
+	background: transparent;
 	text-decoration: none;
 }
 


### PR DESCRIPTION
fixes #681

Since hendrik has no objection I just changed the default bg to transparent