### PR TITLE
Fix plugin package name

### DIFF
--- a/plugin/composer.json
+++ b/plugin/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "wpmunich/lhbpp",
+  "name": "wpmunich/lhpbpp",
   "type": "wordpress-plugin",
   "optimize-autoloader": true,
   "require": {


### PR DESCRIPTION
## Summary
- fix package name in `plugin/composer.json`

## Testing
- `composer validate` *(fails: command not found)*