### PR TITLE
feat(theme): register nav menus on init

### DIFF
--- a/theme/inc/Nav_Menus/Nav_Menus.php
+++ b/theme/inc/Nav_Menus/Nav_Menus.php
@@ -53,7 +53,9 @@ class Nav_Menus extends Theme_Component {
 	/**
 	 * {@inheritdoc}
 	 */
-	protected function add_actions() {}
+	protected function add_actions() {
+		add_action( 'init', array( $this, 'action_register_nav_menus' ) );
+	}
 
 	/**
 	 * {@inheritdoc}

--- a/theme/tests/Nav_Menus_Test.php
+++ b/theme/tests/Nav_Menus_Test.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Nav menus tests.
+ *
+ * @package lhpbp\theme
+ */
+
+use function WpMunich\lhpbp\theme\theme;
+
+/**
+ * Class Nav_Menus_Test
+ */
+class Nav_Menus_Test extends WP_UnitTestCase {
+
+	/**
+	 * Ensure menu locations are registered.
+	 */
+	public function test_nav_menu_locations_registered() {
+		theme();
+		do_action( 'init' );
+
+		$registered = get_registered_nav_menus();
+		$this->assertArrayHasKey( 'header', $registered );
+		$this->assertArrayHasKey( 'footer', $registered );
+	}
+
+	/**
+	 * Test that a menu assigned to a location is detected as active.
+	 */
+	public function test_is_nav_menu_active() {
+		$theme = theme();
+		do_action( 'init' );
+
+		$menu_id             = wp_create_nav_menu( 'Header Menu' );
+		$locations           = get_theme_mod( 'nav_menu_locations', array() );
+		$locations['header'] = $menu_id;
+		set_theme_mod( 'nav_menu_locations', $locations );
+
+		$this->assertTrue( $theme->nav_menus()->is_nav_menu_active( 'header' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- hook nav menu registration on `init`
- add tests covering nav menu registration and activation

## Testing
- `npm run lint`
- `npm run test:unit:env:theme` *(fails: Could not connect to Docker)*